### PR TITLE
'K' binding should be nnoremap, is nmap

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -653,7 +653,7 @@ nmap zS <Plug>ScripteaseSynnames
 
 augroup scriptease_help
   autocmd!
-  autocmd FileType vim nmap <silent><buffer> K :exe 'help '.<SID>helptopic()<CR>
+  autocmd FileType vim nnoremap <silent><buffer> K :exe 'help '.<SID>helptopic()<CR>
 augroup END
 
 function! s:helptopic()


### PR DESCRIPTION
I thought this was because of `<SID>`, but it seems that works fine in `nore` mappings.

Problem is if I `noremap : ;` this breaks the `K` mapping.
