### PR TITLE
Prevent redrawing right after :Time

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -684,6 +684,7 @@ function! s:time(cmd)
   try
     execute a:cmd
   finally
+    redraw
     echomsg matchstr(reltimestr(reltime(time)), '.*\..\{,3\}') . ' seconds to run :'.a:cmd
   endtry
   return ''


### PR DESCRIPTION
Forcing an early redraw ensures that the `:echomsg` is not cleared by Vim redrawing the screen after `:Time` is finished executing.

Cf. `:help :echo-redraw`
