### PR TITLE
Only remap q for preview window

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -250,7 +250,7 @@ function! s:Verbose(level, excmd)
         \ 'finally|' .
         \ 'let &verbosefile = '.string(verbosefile).'|' .
         \ 'endtry|' .
-        \ 'pedit '.temp.'|wincmd P|nnoremap q :bd<CR>'
+        \ 'pedit '.temp.'|wincmd P|nnoremap <buffer> q :bd<CR>'
 endfunction
 
 " }}}1


### PR DESCRIPTION
Prevent map from applying to any other windows with <buffer>.

Otherwise once I used Verbose once, I couldn't record macros anymore.
