### PR TITLE
Add automatic :Runtime for Vim scripts

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Enjoy this amalgamation of crap I use for editing runtime files.
 
 * `:PP`: Pretty print.
 * `:Runtime`: Reload runtime files.  Like `:runtime!`, but it unlets any
-  include guards first.
+  include guards first. Can be configured to run upon saving Vim scripts.
 * `:Disarm`: Remove a runtime file's maps, commands, and autocommands,
   effectively disabling it.
 * `:Scriptnames`: Load `:scriptnames` into the quickfix list.

--- a/doc/scriptease.txt
+++ b/doc/scriptease.txt
@@ -71,6 +71,10 @@ g!{motion}              Call |eval()| on the text the motion moves over and
                         |:unlet|ting any include guards in the relevant
                         syntax, indent, and ftplugin files.
 
+                                                *scriptease-:ToggleAutoRuntime*
+:ToggleAutoRuntime      Toggle whether |:Runtime| should be run after saving
+                        Vim scripts or not.
+
                                                 *scriptease-:Scriptnames*
 :Scriptnames            Load |:scriptnames| into the quickfix list and
                         |:copen|.

--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -342,6 +342,10 @@ function! s:runtime(bang, ...) abort
   let do = []
   let predo = ''
 
+  if a:bang && (!exists('g:scriptease_auto_runtime') || !g:scriptease_auto_runtime)
+    return ""
+  endif
+
   if a:0
     let files = a:000
   elseif &filetype ==# 'vim' || expand('%:e') ==# 'vim'
@@ -390,8 +394,17 @@ function! s:runtime(bang, ...) abort
   return predo.run
 endfunction
 
+function! s:toggle_auto_runtime(bang)
+  let g:scriptease_auto_runtime =
+        \ !exists('g:scriptease_auto_runtime') || g:scriptease_auto_runtime == 0
+  echo 'Auto reloading ' . (g:scriptease_auto_runtime ? 'enabled' : 'disabled')
+endfunction
+
 command! -bang -bar -nargs=* -complete=customlist,s:Complete Runtime
       \ :exe s:runtime('<bang>', <f-args>)
+
+command! -bang -bar -nargs=0 ToggleAutoRuntime
+      \ :call s:toggle_auto_runtime("<bang>")
 
 " }}}1
 " :Disarm {{{1
@@ -701,6 +714,8 @@ augroup scriptease
   " Recent versions of vim.vim set iskeyword to include ":", which breaks among
   " other things tags. :(
   autocmd Syntax vim setlocal iskeyword-=:
+
+  autocmd BufWritePost *.vim silent exe s:runtime('<bang>')
 augroup END
 
 " }}}1


### PR DESCRIPTION
This is something I've been using for a while. It simply runs `:Runtime` on a .vim file after saving it. It saves time in my feedback loop while writing Vim scripts.

I cleaned it up a bit, made it optional and off by default, and added it to the docs and README. 
