### PR TITLE
Fix 'path' option being replaced with runtimepath

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -727,6 +727,12 @@ function! s:helptopic()
   endif
 endfunction
 
+function! s:build_path()
+  let old_path = substitute(&path, '\v^\.,/%(usr|emx)/include,,,?', '', '')
+  let new_path = escape(&runtimepath, ' ')
+  return !empty(old_path) ? old_path.','.new_path : new_path
+endfunction
+
 " }}}1
 " Settings {{{1
 
@@ -738,7 +744,7 @@ endfunction
 
 augroup scriptease
   autocmd!
-  autocmd FileType vim,help let &l:path = escape(&runtimepath, ' ')
+  autocmd FileType vim,help let &l:path = s:build_path()
   autocmd FileType help command! -bar -bang -buffer Console PP
   autocmd FileType vim call s:setup()
   " Recent versions of vim.vim set iskeyword to include ":", which breaks among


### PR DESCRIPTION
We want to append to the existing 'path', instead of replacing it, because it might contain entries previously added by the user.

In my scenario, instead of a fuzzy finder, I have in my .vimrc

``` vim
set path+=**
```

So, when I'm working on a Vim plugin, then my path (including `**`) gets replaced by the runtimepath, and it could just be appended instead.
