### PR TITLE
Improve unlet-search-pattern

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -339,7 +339,7 @@ function! s:unlet_for(files) abort
       let lines = readfile(file)
       if len(lines)
         for i in range(len(lines)-1)
-          let unlet = matchstr(lines[i], '^if exists([''"]\%(\g:\)\=\zs\w\+\ze[''"]')
+          let unlet = matchstr(lines[i], '^if \+\%(( *\)\?exists *( *[''"]\%(\g:\)\=\zs\w\+\ze[''"]')
           if unlet !=# '' && (lines[i+1] =~# '^ *finish\>' || lines[i] =~# '| *finish\>')
                 \ && index(guards, unlet) == -1
             call extend(guards, [unlet])


### PR DESCRIPTION
I've noticed that vim-scriptease did not handle https://github.com/embear/vim-localvimrc's guard:

```
if (exists("g:loaded_localvimrc") || &cp)
  finish
endif
let g:loaded_localvimrc = 1
```

It also fixes #8.
