### PR TITLE
Fix eval operator if 'unnamedplus' is in 'clipboard

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -248,7 +248,7 @@ function! s:filterop(type) abort
     let expr = s:opfunc(a:type)
     let @@ = matchstr(expr, '^\_s\+').scriptease#dump(eval(s:gsub(expr,'\n%(\s*\\)=',''))).matchstr(expr, '\_s\+$')
     if @@ !~# '^\n*$'
-      normal! gvp
+      normal! gv""p
     endif
   catch /^.*/
     echohl ErrorMSG


### PR DESCRIPTION
When the option 'clipboard' contains the value 'unnamedplus', the eval
operator, `g!`, doesn't work as expected.
Instead of putting the evaluation of an expression, it puts the contents
of the `+` register. In this case, the latter differs from the contents
of the unnamed register.

To reproduce:

```
vim -Nu NONE -c 'set rtp+=~/.vim/bundle/vim-scriptease' \
         -c 'runtime plugin/scriptease.vim' \
         -c 'set clipboard^=unnamedplus' \
         -c 'norm! i1+1'
```

Then hit `g!!` on the line. It doesn't replace it with `2`. It puts the
contents of the plus register.

We could tell the normal put command `p` to explicitly put the unnamed
register, so that the `g!` operator works no matter the value of
'clipboard'.