### PR TITLE
Make global and local mappings configurable (extends #21)

### DIFF
--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -261,9 +261,15 @@ endfunction
 
 nnoremap <silent> <Plug>ScripteaseFilter :<C-U>set opfunc=<SID>filterop<CR>g@
 xnoremap <silent> <Plug>ScripteaseFilter :<C-U>call <SID>filterop(visualmode())<CR>
-nmap g! <Plug>ScripteaseFilter
-nmap g!! <Plug>ScripteaseFilter_
-xmap g! <Plug>ScripteaseFilter
+if !hasmapto('<Plug>ScripteaseFilter', 'n')
+  nmap g! <Plug>ScripteaseFilter
+endif
+if !hasmapto('<Plug>ScripteaseFilter_', 'n')
+  nmap g!! <Plug>ScripteaseFilter_
+endif
+if !hasmapto('<Plug>ScripteaseFilter', 'v')
+  xmap g! <Plug>ScripteaseFilter
+endif
 
 " }}}1
 " :Verbose {{{1
@@ -690,7 +696,9 @@ function! s:zS(count)
 endfunction
 
 nnoremap <silent> <Plug>ScripteaseSynnames :<C-U>exe <SID>zS(v:count)<CR>
-nmap zS <Plug>ScripteaseSynnames
+if !hasmapto('<Plug>ScripteaseSynnames', 'n')
+  nmap zS <Plug>ScripteaseSynnames
+endif
 
 " }}}1
 " K {{{1

--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -695,9 +695,13 @@ nmap zS <Plug>ScripteaseSynnames
 " }}}1
 " K {{{1
 
+nnoremap <silent> <Plug>ScripteaseHelp :<C-U>exe 'help '.<SID>helptopic()<CR>
 augroup scriptease_help
   autocmd!
-  autocmd FileType vim nnoremap <silent><buffer> K :exe 'help '.<SID>helptopic()<CR>
+  autocmd FileType vim
+        \  if empty(mapcheck('K', 'n'))
+        \| nmap <silent><buffer> K <Plug>ScripteaseHelp
+        \| endif
 augroup END
 
 function! s:helptopic()


### PR DESCRIPTION
#21 allows to change / disable the buffer-local K mapping; this adds a commit so that the global default mappings for `g!`/`g!!` and `zS` can be changed / disabled (without modifying the plugin), too.

(I already have an alternative implementation of g!, and zS clashed with one of my mappings.)