### PR TITLE
s:unlet_for: only match variables in exists() pattern

### DIFF
--- a/autoload/scriptease.vim
+++ b/autoload/scriptease.vim
@@ -374,7 +374,7 @@ function! s:unlet_for(files) abort
       let lines = readfile(file, '', 500)
       if len(lines)
         for i in range(len(lines)-1)
-          let unlet = matchstr(lines[i], '^if .*\<exists *( *[''"]\%(\g:\)\=\zs[0-9A-Za-z_#]\+\ze[''"]')
+          let unlet = matchstr(lines[i], '^if .*\<exists *( *[''"]\%(\g:\)\=\zs[A-Za-z][0-9A-Za-z_#]*\ze[''"]')
           if unlet !=# '' && index(guards, unlet) == -1
             for j in range(0, 4)
               if get(lines, i+j, '') =~# '^\s*finish\>'


### PR DESCRIPTION
This handles the check used by Vim's matchparen:

> if exists("g:loaded_matchparen") || &cp || !exists("##CursorMoved")

Without this change it would match the `##CursorMoved` and try to unlet
`g:##CursorMoved`.

An alternate / additional idea would be to change `if .*\<exists` to `if
.\=\<exists`.