### PR TITLE
Fix eval mapping when used with unnamed clipboard

### DIFF
--- a/autoload/scriptease.vim
+++ b/autoload/scriptease.vim
@@ -220,15 +220,9 @@ endfunction
 " Section: g!
 
 function! s:opfunc(t) abort
-  let saved = [&selection, &clipboard, @@]
-  try
-    set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
-    silent exe "norm! `[" . get({'l': 'V', 'b': "\<C-V>"}, a:t[0], 'v') . "`]y"
-    redraw
-    return @@
-  finally
-    let [&selection, &clipboard, @@] = saved
-  endtry
+  silent exe "norm! `[" . get({'l': 'V', 'b': "\<C-V>"}, a:t[0], 'v') . "`]y"
+  redraw
+  return @@
 endfunction
 
 function! scriptease#filterop(...) abort
@@ -236,8 +230,9 @@ function! scriptease#filterop(...) abort
     set opfunc=scriptease#filterop
     return 'g@'
   endif
-  let reg_save = @@
+  let saved = [&selection, &clipboard, @@]
   try
+    set selection=inclusive clipboard-=unnamed clipboard-=unnamedplus
     let expr = s:opfunc(a:1)
     let @@ = matchstr(expr, '^\_s\+').scriptease#dump(eval(s:gsub(expr,'\n%(\s*\\)=',''))).matchstr(expr, '\_s\+$')
     if @@ !~# '^\n*$'
@@ -248,7 +243,7 @@ function! scriptease#filterop(...) abort
     echo v:errmsg
     echohl NONE
   finally
-    let @@ = reg_save
+    let [&selection, &clipboard, @@] = saved
   endtry
 endfunction
 


### PR DESCRIPTION
Use same logic in `scriptease#filterop` as used in `s:opfunc` to ensure
the unnamed clipboard isn't used during the `normal! gvp` command.

This fixes the `g=` mapping when used together with `set
clipboard=unnamed`.