### PR TITLE
Implement RtpAdd

### DIFF
--- a/autoload/scriptease.vim
+++ b/autoload/scriptease.vim
@@ -807,4 +807,14 @@ function! scriptease#setup_help() abort
   command! -bar -bang -buffer Console PP
 endfunction
 
+function! scriptease#rtp_add_command(...) abort
+  let l:cmd = 'set runtimepath^='
+  if a:0
+    let l:dirs = a:000
+  else
+    let l:dirs = [getcwd()]
+  endif
+  return l:cmd . join(l:dirs, ',')
+endfunction
+
 " vim:set et sw=2:

--- a/doc/scriptease.txt
+++ b/doc/scriptease.txt
@@ -88,6 +88,11 @@ g!                      Old alias for |g=|.
                         |:unlet|ting any include guards in the relevant
                         syntax, indent, and ftplugin files.
 
+                                                *scriptease-:RtpAdd*
+:RtpAdd                 Prepend the current directory to 'runtimepath'.
+
+:RtpAdd {dir} ..        Prepend given directories to 'runtimepath'.
+
                                                 *scriptease-:Scriptnames*
 :Scriptnames            Load |:scriptnames| into the quickfix list and
                         |:copen|.

--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -59,6 +59,8 @@ command! -bar -bang Messages :execute scriptease#messages_command(<bang>0)
 command! -bang -bar -range=-1 -nargs=* -complete=customlist,scriptease#complete Runtime
       \ :exe scriptease#runtime_command('<bang>', <f-args>)
 
+command! -bar -nargs=* RtpAdd :execute scriptease#rtp_add_command(<f-args>)
+
 command! -bang -bar -nargs=* -complete=customlist,scriptease#complete Disarm
       \ :exe scriptease#disarm_command(<bang>0, <f-args>)
 


### PR DESCRIPTION
A common use case for this would be editing a plugin: the user runs
```
:RtpAdd
```
and then has their plugin directory available live for testing.

Why is this needed?

It is different from `Runtime`: `Runtime` only works for individual files.
If I have a plugin with commands that depend on autoload functions, or a
colorscheme, `Runtime` doesn't suit me. In the first case, I have to call
`Runtime` twice. In the second, I may not want to immediately run the
colorscheme (or it may *need* to be in the `'runtimepath'`). A third case:
the user wants to verify their plugin's documentation is correct.
```
:RtpAdd | help my-plugin
```
should now load the live version (not the version installed in `~/.vim`,
for example).

An additional benefit is that `Ve` and friends now automatically learn
about the plugin files in my current directory (the plugin I'm working
on).

Why does scriptease need this?

I could add this to my own `~/.vim` and call it a day, but scriptease is
fundamentally about vim script and plugin development. This may be
useful to others besides me (as my use cases demonstrate). Ultimately,
if the patch is rejected, I will still be able to add this to my own
vim, with very minor modifications.