### PR TITLE
Support :{count}Messages

### DIFF
--- a/autoload/scriptease.vim
+++ b/autoload/scriptease.vim
@@ -308,13 +308,14 @@ endfunction
 
 " Section: :Messages
 
-function! scriptease#messages_command(bang, arg) abort
+function! scriptease#messages_command(bang, count, arg) abort
+  let command = (a:count > -1 ? a:count : '') . 'messages'
   if !empty(a:arg)
-    return 'messages ' . a:arg
+    return command . ' ' . a:arg
   endif
   let qf = []
   let virtual = get(g:, 'virtual_scriptnames', {})
-  for line in split(scriptease#capture('messages'), '\n\+')
+  for line in split(scriptease#capture(command), '\n\+')
     let lnum = matchstr(line, '\C^line\s\+\zs\d\+\ze:$')
     if lnum && len(qf) && qf[-1].text =~# ':$'
       let qf[-1].text = substitute(qf[-1].text, ':$', '[' . lnum . ']:', '')

--- a/doc/scriptease.txt
+++ b/doc/scriptease.txt
@@ -54,7 +54,12 @@ g!                      Old alias for |g=|.
                         number combinations will be translated to the
                         appropriate file name and line number.
 
+:{count}Messages        Show the {count} most recent messages.
+
 :Messages clear         Clear all messages.
+
+:{count}Messages clear  Clear messages, keeping on the {count} most recent
+                        ones.
 
                                                 *scriptease-:PP*
 :PP {expr}              Pretty print the value of {expr}.

--- a/plugin/scriptease.vim
+++ b/plugin/scriptease.vim
@@ -56,7 +56,8 @@ exe s:othercmd '-bar -count=0 Scriptnames'
       \ 'copen |'
       \ '<count>'
 
-command! -bar -bang -nargs=? Messages :execute scriptease#messages_command(<bang>0, <q-args>)
+exe s:othercmd '-bar -bang -nargs=? -range=-1 Messages'
+      \ 'exe scriptease#messages_command(<bang>0, <count>, <q-args>)'
 
 command! -bang -bar -range=-1 -nargs=* -complete=customlist,scriptease#complete Runtime
       \ :exe scriptease#runtime_command('<bang>', <f-args>)


### PR DESCRIPTION
Submitting this PR since I said I'd do it.  I'm curious—is there a way to default `-count` to a negative number?  The builtin `:0messages` will show 1 message but since `-count=-1` will default to `0`, I can't reproduce this odd behaviour as there doesn't seem to be a way to check that no count was supplied—I'm assuming this isn't a big deal.